### PR TITLE
Beautify event pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4156,6 +4156,12 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "all-contributors-cli": "^6.2.0",
     "babel-plugin-styled-components": "^1.10.0",
+    "date-fns": "^1.30.1",
     "gatsby-plugin-styled-components": "^3.0.6",
     "prettier": "^1.16.4"
   },

--- a/src/components/event.js
+++ b/src/components/event.js
@@ -1,0 +1,67 @@
+import React from "react";
+import styled from "styled-components";
+import format from "date-fns/format";
+import isBefore from "date-fns/is_before";
+
+const EventCard = styled.li`
+  border-radius: 6px;
+  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2), 0 1px 2px 0 rgba(0, 0, 0, 0.2);
+  list-style: none;
+  margin: 1.5em auto;
+  padding: 1em;
+  padding-bottom: 1.25em;
+
+  :last-child {
+    margin-bottom: 5em;
+  }
+`;
+
+const EventDescription = styled.div``;
+
+const EventName = styled.h2`
+  color: #2e3e48;
+  font-size: 1.35rem;
+  margin-top: 0;
+`;
+
+const EventTime = styled.h4`
+  color: #00a2c7;
+  margin-bottom: 0.5em;
+  margin-top: 0;
+  text-transform: uppercase;
+`;
+
+const RSVPLink = styled.a`
+  background-color: #00a2c7;
+  border-radius: 3px;
+  color: #ffffff;
+  padding: 0.5em;
+
+  :hover {
+    background-color: #018dae;
+  }
+`;
+
+const abbreviatedDateFmt = "ddd, MMM D";
+const timeFmt = "h:mm aa";
+const eventAbbrDate = date => format(date, abbreviatedDateFmt);
+const readableTime = unixMillis => format(unixMillis, timeFmt);
+
+export const Event = ({ eventData }) => (
+  <EventCard>
+    <EventTime>
+      {`${eventAbbrDate(eventData.local_date)}, ${readableTime(
+        eventData.time
+      )}`}
+    </EventTime>
+    <a href={eventData.link}>
+      <EventName>{eventData.name}</EventName>
+    </a>
+    <EventDescription
+      dangerouslySetInnerHTML={{ __html: eventData.description }}
+    />
+    {isBefore(eventData.time, Date.now()) ? null : (
+      <RSVPLink href={eventData.link}>RSVP</RSVPLink>
+    )}
+  </EventCard>
+);

--- a/src/templates/events.js
+++ b/src/templates/events.js
@@ -1,29 +1,23 @@
 import React from "react";
 import { graphql } from "gatsby";
-import styled from "styled-components";
 
 import Layout from "../components/layout";
 import SEO from "../components/seo";
-
-const EventStyles = styled.li`
-  list-style: none;
-`;
-
-const EventCard = ({ eventData }) => (
-  <EventStyles>
-    <h2>{eventData.name}</h2>
-    <a href={eventData.link}>RSVP Here!</a>
-  </EventStyles>
-);
+import { Event } from "../components/event";
 
 const EventTemplate = ({ data }) => {
   const {
     meetupGroup: { childrenMeetupEvent },
     markdownRemark: { frontmatter },
   } = data;
-  const events = childrenMeetupEvent.filter(
+  let events = childrenMeetupEvent.filter(
     meetup => meetup.status === frontmatter.eventStatus
   );
+
+  if (frontmatter.eventStatus === "upcoming") {
+    events = events.reverse().slice(0, 3);
+  }
+
   return (
     <Layout>
       <SEO
@@ -31,7 +25,9 @@ const EventTemplate = ({ data }) => {
         keywords={[`meetup`, `community`, `react`]}
       />
       <h1>{frontmatter.title}</h1>
-      {events && events.map(eventData => <EventCard eventData={eventData} />)}
+      {events.map(eventData => (
+        <Event eventData={eventData} />
+      ))}
     </Layout>
   );
 };


### PR DESCRIPTION
### What's This PR Do?
Updates content and styling of event templates as an unrequested stab at #20. Please let me know if there's anything I can tweak.
* Introduces a card format for some visual separation between events
* Adds event date/time and descriptions
* Removes RSVP links for past events
* For upcoming events, 
  * limits to the next 3
  * sorts ascending so the next coming event is at top

### Assumptions I Made
* It's safe to `dangerouslySetInnerHTML` with content from meetup.com because meetup.com sanitizes event content on their end
* It's ok to include all past events on that page, for now, even though the page gets pretty long once all the descriptions are loaded in there. 
  * Perhaps it would be better to limit this to the last half dozen or so events followed by a "See All" link to meetup.com?

### Screenshots

#### Past Events (also demos wider screen size)
<img width="1232" alt="Screen Shot 2019-03-28 at 1 12 25 AM" src="https://user-images.githubusercontent.com/5862724/55138051-22f36a00-50f8-11e9-878a-3bf92a25d027.png">

#### Upcoming Events (also demos narrow screen width)
<img width="445" alt="upcoming_small" src="https://user-images.githubusercontent.com/5862724/55138288-b7f66300-50f8-11e9-8a5c-793e81c1ba9a.png">