### PR TITLE
Fix event dates

### DIFF
--- a/app/hooks/useEventDates.tsx
+++ b/app/hooks/useEventDates.tsx
@@ -1,32 +1,16 @@
-// ==========================================================
-//  CHANGE MDX EVENT BACK FROM 21 to 20
-// ==========================================================
-
 export default function useEventDates(events: any[]) {
   const now: Date = new Date();
   const today: Date = new Date(
     Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
   );
-  // console.log(today == new Date(events[5].date));
+
   const eventsPast = events.filter(
     (event) => event.date && today > new Date(event.date)
   );
 
-  // && !isSameDay(today, new Date(event.date))
-
   const eventNext = events.find(
     (event) => event.date && today <= new Date(event.date)
   );
-
-  //  || isSameDay(today, new Date(event.date)))
-
-  // function isSameDay(d1: Date, d2: Date): boolean {
-  //   return (
-  //     d1.getUTCFullYear() === d2.getUTCFullYear() &&
-  //     d1.getUTCMonth() === d2.getUTCMonth() &&
-  //     d1.getUTCDate() === d2.getUTCDate()
-  //   );
-  // }
 
   return { eventNext, eventsPast };
 }

--- a/app/hooks/useEventDates.tsx
+++ b/app/hooks/useEventDates.tsx
@@ -3,14 +3,14 @@ export default function useEventDates(events: any[]) {
   const today: Date = new Date(
     Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
   );
-  console.log(today == new Date(events[5].date));
-  let eventsPast = events.filter(
+  // console.log(today == new Date(events[5].date));
+  const eventsPast = events.filter(
     (event) => event.date && today > new Date(event.date)
   );
 
   // && !isSameDay(today, new Date(event.date))
 
-  let eventNext = events.find(
+  const eventNext = events.find(
     (event) => event.date && today <= new Date(event.date)
   );
 

--- a/app/hooks/useEventDates.tsx
+++ b/app/hooks/useEventDates.tsx
@@ -1,14 +1,14 @@
-export default function useEventDates(eventsAll: any[]) {
+export default function useEventDates(events: any[]) {
   const now: Date = new Date(new Date().setUTCHours(0, 0, 0, 0));
 
-  let eventsPast = eventsAll.filter(
+  let eventsPast = events.filter(
     (event) =>
       event.date &&
       now > new Date(event.date) &&
       !isSameDay(now, new Date(event.date))
   );
 
-  let eventNext = eventsAll.find(
+  let eventNext = events.find(
     (event) =>
       event.date &&
       (now <= new Date(event.date) || isSameDay(now, new Date(event.date)))

--- a/app/hooks/useEventDates.tsx
+++ b/app/hooks/useEventDates.tsx
@@ -1,26 +1,28 @@
 export default function useEventDates(events: any[]) {
-  const now: Date = new Date(new Date().setUTCHours(0, 0, 0, 0));
-
-  let eventsPast = events.filter(
-    (event) =>
-      event.date &&
-      now > new Date(event.date) &&
-      !isSameDay(now, new Date(event.date))
+  const now: Date = new Date();
+  const today: Date = new Date(
+    Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())
   );
+  console.log(today == new Date(events[5].date));
+  let eventsPast = events.filter(
+    (event) => event.date && today > new Date(event.date)
+  );
+
+  // && !isSameDay(today, new Date(event.date))
 
   let eventNext = events.find(
-    (event) =>
-      event.date &&
-      (now <= new Date(event.date) || isSameDay(now, new Date(event.date)))
+    (event) => event.date && today <= new Date(event.date)
   );
 
-  function isSameDay(d1: Date, d2: Date): boolean {
-    return (
-      d1.getFullYear() === d2.getFullYear() &&
-      d1.getMonth() === d2.getMonth() &&
-      d1.getDate() === d2.getDate()
-    );
-  }
+  //  || isSameDay(today, new Date(event.date)))
+
+  // function isSameDay(d1: Date, d2: Date): boolean {
+  //   return (
+  //     d1.getUTCFullYear() === d2.getUTCFullYear() &&
+  //     d1.getUTCMonth() === d2.getUTCMonth() &&
+  //     d1.getUTCDate() === d2.getUTCDate()
+  //   );
+  // }
 
   return { eventNext, eventsPast };
 }

--- a/app/hooks/useEventDates.tsx
+++ b/app/hooks/useEventDates.tsx
@@ -1,3 +1,7 @@
+// ==========================================================
+//  CHANGE MDX EVENT BACK FROM 21 to 20
+// ==========================================================
+
 export default function useEventDates(events: any[]) {
   const now: Date = new Date();
   const today: Date = new Date(

--- a/app/routes/events/index.tsx
+++ b/app/routes/events/index.tsx
@@ -18,9 +18,9 @@ export default function Events() {
   const eventSize = "md";
   const events = useLoaderData<typeof loader>();
 
-  let { eventNext, eventsPast } = useEventDates(events);
+  const { eventNext, eventsPast } = useEventDates(events);
 
-  let eventsShown = eventsPast.concat(eventNext || []).reverse();
+  const eventsShown = eventsPast.concat(eventNext || []).reverse();
 
   return (
     <div className={"events"}>

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -55,10 +55,9 @@ export default function Index() {
 
   const { eventNext, eventsPast } = useEventDates(eventsAll);
 
-  //only show most recent 4 events
   let eventsPastShown = [];
   eventsPast.length > 4 ? (eventsPastShown = eventsPast.slice(-4)) : null;
-  eventsPast.reverse(); //display most recent to oldest
+  eventsPastShown.reverse();
 
   return (
     <div className="page__container">

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -53,10 +53,11 @@ export async function loader() {
 export default function Index() {
   const eventsAll = useLoaderData<typeof loader>();
 
-  let { eventNext, eventsPast } = useEventDates(eventsAll);
+  const { eventNext, eventsPast } = useEventDates(eventsAll);
 
   //only show most recent 4 events
-  eventsPast.length > 4 ? (eventsPast = eventsPast.slice(-4)) : null;
+  let eventsPastShown = [];
+  eventsPast.length > 4 ? (eventsPastShown = eventsPast.slice(-4)) : null;
   eventsPast.reverse(); //display most recent to oldest
 
   return (
@@ -72,7 +73,7 @@ export default function Index() {
         <h2>Catch recordings from previous events:</h2>
 
         {/* insert mapped events here */}
-        {eventsPast.map((event) => (
+        {eventsPastShown.map((event) => (
           <Link key={event.id} to={`./events/${event.slug}`}>
             <Event event={event} size={"small"} />
           </Link>

--- a/content/events/2022-12-20.mdx
+++ b/content/events/2022-12-20.mdx
@@ -1,6 +1,6 @@
 ---
 title: Finding the Joy in Javascript
-date: 2022-12-21
+date: 2022-12-20
 description: Join us for a meetup on finding joy in Javascript again. We'll chat about overcoming burnout and imposter syndrome as a software engineer.
 location: 1595 Wynkoop St, Denver, CO 80202
 speakers:

--- a/content/events/2022-12-20.mdx
+++ b/content/events/2022-12-20.mdx
@@ -1,6 +1,6 @@
 ---
 title: Finding the Joy in Javascript
-date: 2022-12-20
+date: 2022-12-21
 description: Join us for a meetup on finding joy in Javascript again. We'll chat about overcoming burnout and imposter syndrome as a software engineer.
 location: 1595 Wynkoop St, Denver, CO 80202
 speakers:


### PR DESCRIPTION
Dates are now compared using UTC midnight dates. Pages now display all past events plus one next event, with the next event being a future event or on the same day the page is viewed.